### PR TITLE
Do unlensed solardipole

### DIFF
--- a/202002_foregrounds_extragalactic_cmb_tophat/README.md
+++ b/202002_foregrounds_extragalactic_cmb_tophat/README.md
@@ -58,7 +58,7 @@ Also created a single set of maps which is the sum of all components. They are a
 
 * `combined_foregrounds`: sum of `dust`, `synchrotron`, `freefree`, `ame`, `cib`, `ksz`, `tsz`
 * `cmb_lensing_signal`: `cmb` minus `cmb_unlensed`
-* `cmb_lensed_solardipole_nest`: `cmb_lensed_solardipole`, just reordered to HEALPix NEST
+* `cmb_unlensed_solardipole_nest`: `cmb_unlensed_solardipole`, just reordered to HEALPix NEST
 * `cmb_tensor_nest`: `cmb_tensor`, just reordered to HEALPix NEST
 
 They are in the same folder and same naming convention, e.g.:

--- a/202002_foregrounds_extragalactic_cmb_tophat/cmb_unlensed_solardipole.toml
+++ b/202002_foregrounds_extragalactic_cmb_tophat/cmb_unlensed_solardipole.toml
@@ -1,0 +1,13 @@
+
+tag = "cmb_unlensed_solardipole"
+
+[ pysm_components ]
+# do not apply any rotation
+pysm_output_reference_frame = "C"
+
+    [ pysm_components.cmb ]
+    class  =  "so_pysm_models.WebSkyCMBMap"
+    websky_version = "0.3"
+    lensed = false
+    include_solar_dipole = true
+    seed = 1

--- a/202002_foregrounds_extragalactic_cmb_tophat/combine_maps.py
+++ b/202002_foregrounds_extragalactic_cmb_tophat/combine_maps.py
@@ -6,7 +6,7 @@ all_combined = {
     "combined_foregrounds": ["dust", "synchrotron", "freefree", "ame"]
     + ["cib", "ksz", "tsz"],
     "cmb_lensing_signal": ["cmb", "-cmb_unlensed"],
-    "cmb_lensed_solardipole_nest": ["cmb_lensed_solardipole"],
+    "cmb_unlensed_solardipole_nest": ["cmb_unlensed_solardipole"],
     "cmb_tensor_nest": ["cmb_tensor"],
 }
 

--- a/202002_foregrounds_extragalactic_cmb_tophat/prepare_slurm_scripts_by_freq.py
+++ b/202002_foregrounds_extragalactic_cmb_tophat/prepare_slurm_scripts_by_freq.py
@@ -5,7 +5,7 @@ folder = Path(f"jobs")
 folder.mkdir(exist_ok=True, parents=True)
 
 nside_sims = ["dust", "freefree", "synchrotron", "ame"]
-no_nside_sims = ["cib", "ksz", "tsz", "cmb", "cmb_tensor", "cmb_unlensed", "cmb_lensed_solardipole"]
+no_nside_sims = ["cib", "ksz", "tsz", "cmb", "cmb_tensor", "cmb_unlensed", "cmb_lensed_solardipole", "cmb_unlensed_solardipole"]
 
 import h5py
 s4 = h5py.File("cmbs4_tophat.h5", mode="r")


### PR DESCRIPTION
@keskitalo I realized I used the lensed CMB, instead I should have used the unlensed CMB, then we can add separately the lensing signal.

sorry about that. Can you please run these through TOAST? 
the name is `cmb_unlensed_solardipole_nest`